### PR TITLE
update logic inside the tenant_klass_defined? method

### DIFF
--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -67,7 +67,7 @@ module MultiTenant
         partition_key = @partition_key
 
         # Create an implicit belongs_to association only if tenant class exists
-        if MultiTenant.tenant_klass_defined?(tenant_name)
+        if MultiTenant.tenant_klass_defined?(tenant_name, options)
           belongs_to tenant_name, **options.slice(:class_name, :inverse_of, :optional)
                                            .merge(foreign_key: options[:partition_key])
         end
@@ -103,7 +103,7 @@ module MultiTenant
             tenant_id
           end
 
-          if MultiTenant.tenant_klass_defined?(tenant_name)
+          if MultiTenant.tenant_klass_defined?(tenant_name, options)
             define_method "#{tenant_name}=" do |model|
               super(model)
               if send("#{partition_key}_changed?") && persisted? && !send("#{partition_key}_was").nil?

--- a/lib/activerecord-multi-tenant/multi_tenant.rb
+++ b/lib/activerecord-multi-tenant/multi_tenant.rb
@@ -5,8 +5,13 @@ module MultiTenant
     attribute :tenant
   end
 
-  def self.tenant_klass_defined?(tenant_name)
-    !!tenant_name.to_s.classify.safe_constantize
+  def self.tenant_klass_defined?(tenant_name, options = {})
+    class_name = if options[:class_name].present?
+      options[:class_name]
+    else
+      tenant_name.to_s.classify
+    end
+    !!class_name.safe_constantize
   end
 
   def self.partition_key(tenant_name)

--- a/spec/activerecord-multi-tenant/multi_tenant_spec.rb
+++ b/spec/activerecord-multi-tenant/multi_tenant_spec.rb
@@ -64,4 +64,24 @@ RSpec.describe MultiTenant do
       end
     end
   end
+
+  describe '.tenant_klass_defined?' do
+    let(:sample_tenant_class) { Struct.new('SampleTenant') }
+
+    context 'without options' do
+      tenant_name = :sample_tenant
+      expect(MultiTenant.tenant_klass_defined?(tenant_name)).to eq(true)
+
+      invalid_tenant_name = :tenant
+      expect(MultiTenant.tenant_klass_defined?(invalid_tenant_name)).to eq(false)
+    end
+
+    context 'with options' do
+      tenant_name = :tenant
+      options = {
+        class_name: 'SampleTenant'
+      }
+      expect(MultiTenant.tenant_klass_defined?(tenant_name, options)).to eq(true)
+    end
+  end
 end

--- a/spec/activerecord-multi-tenant/multi_tenant_spec.rb
+++ b/spec/activerecord-multi-tenant/multi_tenant_spec.rb
@@ -66,22 +66,30 @@ RSpec.describe MultiTenant do
   end
 
   describe '.tenant_klass_defined?' do
-    let(:sample_tenant_class) { Struct.new('SampleTenant') }
+    before(:all) do
+      class SampleTenant; end
+    end
 
     context 'without options' do
-      tenant_name = :sample_tenant
-      expect(MultiTenant.tenant_klass_defined?(tenant_name)).to eq(true)
+      it 'return true with valid tenant_name' do
+        tenant_name = :sample_tenant
+        expect(MultiTenant.tenant_klass_defined?(tenant_name)).to eq(true)
+      end
 
-      invalid_tenant_name = :tenant
-      expect(MultiTenant.tenant_klass_defined?(invalid_tenant_name)).to eq(false)
+      it 'return false with invalid_tenant_name tenant_name' do
+        invalid_tenant_name = :tenant
+        expect(MultiTenant.tenant_klass_defined?(invalid_tenant_name)).to eq(false)
+      end
     end
 
     context 'with options' do
-      tenant_name = :tenant
-      options = {
-        class_name: 'SampleTenant'
-      }
-      expect(MultiTenant.tenant_klass_defined?(tenant_name, options)).to eq(true)
+      it 'return true with valid class_name' do
+        tenant_name = :tenant
+        options = {
+          class_name: 'SampleTenant'
+        }
+        expect(MultiTenant.tenant_klass_defined?(tenant_name, options)).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION
I think `options[:class_name]` should also be a determining factor inside `tenant_klass_defined?` method.

I think the following issue is related.
https://github.com/citusdata/activerecord-multi-tenant/issues/105